### PR TITLE
Add framework logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,14 @@ framework.on('spawn', (bot, id, actorId) => {
   }
 });
 
+// Implementing a framework.on('log') handler allows you to capture
+// events emitted from the framework.  Its a handy way to better understand
+// what the framework is doing when first getting started, and a great 
+// way to troubleshoot issues.
+// You may wish to disable this for production apps
+framework.on('log', (msg) => {
+  console.log(msg);
+});
 
 //Process incoming messages
 


### PR DESCRIPTION
Add a handler for framework log events in the sample app.   This can be useful for new users trying to troubleshoot issues with the bot not handling messages.    See https://github.com/WebexSamples/webex-node-bot-framework#troubleshooting